### PR TITLE
Adds ability for organizers to add trip members

### DIFF
--- a/app/controllers/api/v1/members_controller.rb
+++ b/app/controllers/api/v1/members_controller.rb
@@ -5,4 +5,19 @@ class Api::V1::MembersController < Api::ApiController
   def index
     @members = @trip.members
   end
+
+  def create
+    set_member
+    @trip.members << @member
+  end
+
+  private
+
+  def set_member
+    @member ||= User.find_by(email: member_params[:email]) || User.create(member_params)
+  end
+
+  def member_params
+    params.require(:member).permit(:name, :email)
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,7 +14,7 @@ class Ability
     can [:add_expense, :view_expenses, :view_members, :view_payments], Trip do |trip|
       trip.memberships.pluck(:user_id).include?(user.id)
     end
-    can :add_members, Trip do |trip|
+    can [:add_member, :add_members], Trip do |trip|
       trip.organizer_id == user.id
     end
 

--- a/app/views/api/v1/members/_member.json.jbuilder
+++ b/app/views/api/v1/members/_member.json.jbuilder
@@ -1,0 +1,10 @@
+json.partial! 'api/v1/users/user', user: member
+
+json.total_purchased_amount member.purchases.where(trip: trip).sum(:cost)
+json.total_obligated_amount trip.total_owed_from(member)
+json.total_contributed_amount trip.total_contributed_from(member)
+json.owes_current_user member.owes_user(current_user, trip)
+
+json.actions do
+  json.view_payments(url: api_link(api_v1_user_payments_path(member, trip_id: trip.id)), method: 'GET') if can?(:view_payments, trip)
+end

--- a/app/views/api/v1/members/create.json.jbuilder
+++ b/app/views/api/v1/members/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'member', member: @member, trip: @trip

--- a/app/views/api/v1/members/index.json.jbuilder
+++ b/app/views/api/v1/members/index.json.jbuilder
@@ -1,12 +1,3 @@
 json.array! @members do |member|
-  json.partial! 'api/v1/users/user', user: member
-
-  json.total_purchased_amount member.purchases.where(trip: @trip).sum(:cost)
-  json.total_obligated_amount @trip.total_owed_from(member)
-  json.total_contributed_amount @trip.total_contributed_from(member)
-  json.owes_current_user member.owes_user(current_user, @trip)
-
-  json.actions do
-    json.view_payments(url: api_link(api_v1_user_payments_path(member, trip_id: @trip.id)), method: 'GET') if can?(:view_payments, @trip)
-  end
+  json.partial! 'member', member: member, trip: @trip
 end

--- a/app/views/api/v1/trips/_trip.json.jbuilder
+++ b/app/views/api/v1/trips/_trip.json.jbuilder
@@ -12,5 +12,6 @@ json.actions do
   json.delete(url: api_link(api_v1_trip_path(trip)), method: 'DELETE') if can?(:destroy, trip)
   json.create_expense(url: api_link(api_v1_trip_expenses_path(trip)), method: 'POST') if can?(:add_expense, trip)
   json.view_expenses(url: api_link(api_v1_trip_expenses_path(trip)), method: 'GET') if can?(:view_expenses, trip)
+  json.create_member(url: api_link(api_v1_trip_members_path(trip)), method: 'POST') if can?(:add_member, trip)
   json.view_members(url: api_link(api_v1_trip_members_path(trip)), method: 'GET') if can?(:view_members, trip)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ GroupExpenser::Application.routes.draw do
       end
 
       resources :trips, only: [:create, :show, :index, :update, :destroy] do
-        resources :members, controller: :members, only: :index
+        resources :members, controller: :members, only: [:index, :create]
         resources :expenses, only: [:create, :show, :index, :update, :destroy]
       end
 


### PR DESCRIPTION
Why
---
We know not everyone will join the trip or some may not have the
ability. If one member doesn't join it throws all the cost sharing off
and makes the app useless.

This change addresses the need by
---------------------------------
Allows organizers to add members manually to the trip.