### PR TITLE
Adds the ability to remove and re-add obligations for an expense

### DIFF
--- a/app/controllers/api/v1/expense_obligations_controller.rb
+++ b/app/controllers/api/v1/expense_obligations_controller.rb
@@ -3,11 +3,23 @@ class Api::V1::ExpenseObligationsController < Api::ApiController
   load_and_authorize_resource :expense, through: :current_user, only: :index
 
   def index
-    @obligations = @expense.obligations.includes(:user)
+    @obligations = @expense.obligations.includes(:user) # TODO: load and authorize
     @user_contributions = @expense.contributions.includes(:user).inject({}) do |user_contributions, contribution|
       user_contributions[contribution.user_id] = contribution
       user_contributions
     end
+  end
+
+  def activate
+    @obligation = ExpenseObligation.find(params[:id])
+    authorize! :activate, @obligation
+    ReactivateObligation.activate(@obligation)
+  end
+
+  def destroy
+    @obligation = ExpenseObligation.find(params[:id])
+    authorize! :destroy, @obligation
+    AnnulObligation.annul(@obligation)
   end
 
   def pay

--- a/app/helpers/api/expense_obligations_helper.rb
+++ b/app/helpers/api/expense_obligations_helper.rb
@@ -2,6 +2,22 @@ module Api::ExpenseObligationsHelper
   def order_expense_obligations(obligations, purchaser: purchaser)
     obligations.sort do |a, b|
       (purchaser.id == a.user_id ? 0 : 1) <=> (purchaser.id == b.user_id ? 0 : 1)
-    end
+    end.sort { |a, b| (a.is_annulled ? 1 : 0) <=> (b.is_annulled ? 1 : 0) }
+  end
+
+  def can_annul?(obligation, contribution)
+    !obligation.is_annulled && !contribution
+  end
+
+  def can_activate?(obligation)
+    obligation.is_annulled
+  end
+
+  def can_pay?(obligation, contribution)
+    !obligation.is_annulled && !contribution
+  end
+
+  def can_unpay?(obligation, contribution)
+    !obligation.is_annulled && contribution
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -43,20 +43,14 @@ class Ability
       obligation.user_id == user.id ||
         obligation.expense.trip.memberships.pluck(:user_id).include?(user.id)
     end
-    can :manage, ExpenseObligation do |obligation|
-      obligation.user_id == user.id
-    end
-    can :manage, ExpenseObligation do |obligation|
-      obligation.expense.purchaser_id == user.id
-    end
-    can :manage, ExpenseObligation do |obligation|
+    can [:pay, :unpay, :activate, :destroy], ExpenseObligation do |obligation|
       obligation.expense.trip.organizer_id == user.id
     end
-    can [:pay, :unpay], ExpenseObligation do |obligation|
+    can [:pay, :unpay, :activate, :destroy], ExpenseObligation do |obligation|
       obligation.user_id == user.id ||
         obligation.expense.purchaser_id == user.id
     end
-    cannot [:pay, :unpay], ExpenseObligation do |obligation|
+    cannot [:pay, :unpay, :activate, :destroy], ExpenseObligation do |obligation|
       obligation.user_id == obligation.expense.purchaser_id
     end
   end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -19,15 +19,14 @@ class Expense < ActiveRecord::Base
 
   # Reaverages the obligations to make sure the full cost is covered of the expense
   def reaverage_obligations
-    obligations.update_all(amount: average_cost)
-    contributions.update_all(amount: average_cost)
+    ReaverageObligations.reaverage(self)
   end
 
   # Gets the cost for a member, factoring in obligations
   # @param [User] member that cost is being calculated for
   # @return [BigDecimal] cost for the member
   def cost_for(member)
-    obligations.select { |x| x.user_id == member.id }.map(&:amount).inject(0, :+)
+    obligations.active.select { |x| x.user_id == member.id }.map(&:amount).inject(0, :+)
   end
 
   # Returns the cost for the purchaser, factoring in contributions
@@ -48,6 +47,6 @@ class Expense < ActiveRecord::Base
   # Gets the average cost of expense for all trip members
   # @return [BigDecimal] average cost of expense
   def average_cost
-    @average_cost ||= cost / trip.members.size
+    @average_cost ||= AverageCostCalculator.calculate(self)
   end
 end

--- a/app/models/expense_obligation.rb
+++ b/app/models/expense_obligation.rb
@@ -6,4 +6,6 @@ class ExpenseObligation < ActiveRecord::Base
 
   validates_presence_of :amount, :user_id
   validates_uniqueness_of :user_id, scope: :expense_id
+
+  scope :active, -> { where(is_annulled: false) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ActiveRecord::Base
   has_many :trips, through: :memberships
   has_many :expenses, through: :trips
   has_many :contributions, class_name: ExpenseContribution, dependent: :destroy
-  has_many :obligations, class_name: ExpenseObligation, dependent: :destroy
+  has_many :obligations, -> { active }, class_name: ExpenseObligation, dependent: :destroy
 
   # Calculates the total cost of the expenses paid for by user of all the trips taken
   # return [BigDecimal] total cost of expenses

--- a/app/queries/peer_to_peer_payments.rb
+++ b/app/queries/peer_to_peer_payments.rb
@@ -28,12 +28,20 @@ class PeerToPeerPayments
   end
 
   def user_purchases
-    @user_purchases ||= @user.purchases.where(trip: @trip)
+    @user_purchases ||= begin
+      purchases = @user.purchases.where(trip: @trip)
+      obligations = @peer.obligations.active.where(expense: purchases)
+      obligations.map(&:expense)
+    end
   end
 
   def peer_purchases
     return [] if same_user?
-    @peer_purchases ||= @peer.purchases.where(trip: @trip)
+    @peer_purchases ||= begin
+      purchases = @peer.purchases.where(trip: @trip)
+      obligations = @user.obligations.active.where(expense: purchases)
+      obligations.map(&:expense)
+    end
   end
 
   def user_contributions

--- a/app/services/annul_obligation.rb
+++ b/app/services/annul_obligation.rb
@@ -1,0 +1,29 @@
+class AnnulObligation
+  def self.annul(obligation)
+    new(obligation).annul
+  end
+
+  def initialize(obligation, reaverage_obligations_service: ReaverageObligations)
+    @obligation = obligation
+    @reaverage_obligations_service = reaverage_obligations_service
+  end
+
+  def annul
+    return false unless can_annul?
+    ExpenseObligation.transaction do
+      obligation.update(is_annulled: true, amount: 0)
+      @reaverage_obligations_service.reaverage(expense)
+    end
+  end
+
+  private
+
+  attr_reader :obligation
+
+  def can_annul?
+    ExpenseContribution.where(user: user, expense: expense).none?
+  end
+
+  delegate :expense, to: :obligation
+  delegate :user, to: :obligation
+end

--- a/app/services/average_cost_calculator.rb
+++ b/app/services/average_cost_calculator.rb
@@ -1,0 +1,19 @@
+class AverageCostCalculator
+  def self.calculate(expense)
+    new(expense).calculate
+  end
+
+  def initialize(expense)
+    @expense = expense
+  end
+
+  def calculate
+    return 0 if obligations.active.count.zero?
+    expense.cost / obligations.active.count
+  end
+
+  private
+  attr_reader :expense
+
+  delegate :obligations, to: :expense
+end

--- a/app/services/payment_amount_calculator.rb
+++ b/app/services/payment_amount_calculator.rb
@@ -10,7 +10,7 @@ class PaymentAmountCalculator
   def calculate
     case payment_object.class.to_s
     when Expense.to_s
-      payment_object.cost / payment_object.trip.members.count
+      payment_object.cost / payment_object.obligations.active.count
     when ExpenseContribution.to_s
       payment_object.amount
     else

--- a/app/services/reactivate_obligation.rb
+++ b/app/services/reactivate_obligation.rb
@@ -1,0 +1,29 @@
+class ReactivateObligation
+  def self.activate(obligation)
+    new(obligation).activate
+  end
+
+  def initialize(obligation, reaverage_obligations_service: ReaverageObligations)
+    @obligation = obligation
+    @reaverage_obligations_service = reaverage_obligations_service
+  end
+
+  def activate
+    return false unless can_activate?
+    ExpenseObligation.transaction do
+      obligation.update(is_annulled: false)
+      @reaverage_obligations_service.reaverage(expense)
+    end
+  end
+
+  private
+
+  attr_reader :obligation
+
+  def can_activate?
+    obligation.is_annulled
+  end
+
+  delegate :expense, to: :obligation
+  delegate :user, to: :obligation
+end

--- a/app/services/reaverage_obligations.rb
+++ b/app/services/reaverage_obligations.rb
@@ -1,0 +1,27 @@
+class ReaverageObligations
+  def self.reaverage(expense)
+    new(expense).reaverage
+  end
+
+  def initialize(expense, average_cost_calculator: AverageCostCalculator)
+    @expense = expense
+    @average_cost_calculator = average_cost_calculator
+  end
+
+  def reaverage
+    Expense.transaction do
+      obligations.active.update_all(amount: average_cost)
+      contributions.update_all(amount: average_cost)
+    end
+  end
+
+  private
+  attr_reader :expense
+
+  delegate :obligations, to: :expense
+  delegate :contributions, to: :expense
+
+  def average_cost
+    @average_cost ||= @average_cost_calculator.calculate(expense)
+  end
+end

--- a/app/views/api/v1/expense_obligations/_obligation.json.jbuilder
+++ b/app/views/api/v1/expense_obligations/_obligation.json.jbuilder
@@ -1,4 +1,4 @@
-json.(obligation, :id, :expense_id)
+json.(obligation, :id, :expense_id, :is_annulled)
 json.amount to_money(obligation.amount)
 
 if contribution
@@ -7,6 +7,9 @@ if contribution
 elsif obligation.user_id == obligation.expense.purchaser_id
   json.label 'Purchased'
   json.is_paid true
+elsif obligation.is_annulled
+  json.label 'Removed'
+  json.is_paid false
 else
   json.label 'Unpaid'
   json.is_paid false
@@ -22,6 +25,8 @@ end
 
 json.actions do
   json.show(url: api_link(api_v1_expense_obligation_path(obligation)), method: 'GET') if can?(:read, obligation)
-  json.pay(url: api_link(pay_api_v1_expense_obligation_path(obligation)), method: 'POST') if can?(:pay, obligation)
-  json.unpay(url: api_link(unpay_api_v1_expense_obligation_path(obligation)), method: 'DELETE') if can?(:unpay, obligation)
+  json.destroy(url: api_link(api_v1_expense_obligation_path(obligation)), method: 'DELETE') if can?(:destroy, obligation) && can_annul?(obligation, contribution)
+  json.activate(url: api_link(activate_api_v1_expense_obligation_path(obligation)), method: 'POST') if can?(:activate, obligation) && can_activate?(obligation)
+  json.pay(url: api_link(pay_api_v1_expense_obligation_path(obligation)), method: 'POST') if can?(:pay, obligation) && can_pay?(obligation, contribution)
+  json.unpay(url: api_link(unpay_api_v1_expense_obligation_path(obligation)), method: 'DELETE') if can?(:unpay, obligation) && can_unpay?(obligation, contribution)
 end

--- a/app/views/api/v1/expense_obligations/activate.jbuilder
+++ b/app/views/api/v1/expense_obligations/activate.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'obligation', obligation: @obligation, contribution: nil

--- a/app/views/api/v1/expense_obligations/destroy.json.jbuilder
+++ b/app/views/api/v1/expense_obligations/destroy.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'obligation', obligation: @obligation, contribution: nil

--- a/app/views/api/v1/expenses/update.json.jbuilder
+++ b/app/views/api/v1/expenses/update.json.jbuilder
@@ -1,7 +1,7 @@
 json.partial! 'expense', expense: @expense
 
 json.obligations do
-  json.array! @expense.obligations do |obligation|
+  json.array! order_expense_obligations(@expense.obligations, purchaser: @expense.purchaser) do |obligation|
     json.partial! 'api/v1/expense_obligations/obligation', obligation: obligation, contribution: @expense.contributions.detect { |c| c.user_id == obligation.user_id }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,4 +29,6 @@ GroupExpenser::Application.configure do
   config.assets.debug = true
 
   config.eager_load = false
+
+  config.active_record.raise_in_transactional_callbacks = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,10 +25,11 @@ GroupExpenser::Application.routes.draw do
         resources :obligations, as: :expense_obligations, controller: :expense_obligations, only: :index
       end
 
-      resources :obligations, as: :expense_obligations, controller: :expense_obligations, only: :show do
+      resources :obligations, as: :expense_obligations, controller: :expense_obligations, only: [:show, :destroy] do
         member do
           post :pay
           delete :unpay
+          post :activate
         end
       end
     end

--- a/db/migrate/20170507025938_add_is_anulled_to_obligations.rb
+++ b/db/migrate/20170507025938_add_is_anulled_to_obligations.rb
@@ -1,0 +1,5 @@
+class AddIsAnulledToObligations < ActiveRecord::Migration
+  def change
+    add_column :expense_obligations, :is_annulled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412010929) do
+ActiveRecord::Schema.define(version: 20170507025938) do
 
   create_table "expense_contributions", force: :cascade do |t|
     t.integer  "user_id"
@@ -27,10 +27,11 @@ ActiveRecord::Schema.define(version: 20170412010929) do
   create_table "expense_obligations", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "expense_id"
-    t.decimal  "amount",     precision: 8, scale: 2
+    t.decimal  "amount",      precision: 8, scale: 2
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "name"
+    t.boolean  "is_annulled",                         default: false
   end
 
   add_index "expense_obligations", ["expense_id"], name: "index_expense_obligations_on_expense_id"


### PR DESCRIPTION
Why
---
Not everyone needs to pay for expenses but currently everyone has the
expense split evenly between them.

This change addresses the need by
---------------------------------
Adds API endpoints to remove and re-add obligations. Adds logic for when
these actions are allowed and who can take them. Also refactored some of
the reaveraging and average calculating logic.